### PR TITLE
[squid:S2259] Null pointers should not be dereferenced

### DIFF
--- a/src/main/java/net/fs/cap/CustomTcpSackOption.java
+++ b/src/main/java/net/fs/cap/CustomTcpSackOption.java
@@ -240,6 +240,7 @@ public final class CustomTcpSackOption implements TcpOption {
 
   @Override
   public boolean equals(Object obj) {
+    if (obj == null) { return false; }
     if (obj == this) { return true; }
     if (!this.getClass().isInstance(obj)) { return false; }
 
@@ -365,6 +366,7 @@ public final class CustomTcpSackOption implements TcpOption {
 
     @Override
     public boolean equals(Object obj) {
+      if (obj == null) { return false; }
       if (obj == this) { return true; }
       if (!this.getClass().isInstance(obj)) { return false; }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2259 - “Null pointers should not be dereferenced”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2259

Please let me know if you have any questions.
Ayman Abdelghany.
