### PR TITLE
[squid:S1118] Utility classes should not have public constructors

### DIFF
--- a/src/main/java/net/fs/cap/PacketUtils.java
+++ b/src/main/java/net/fs/cap/PacketUtils.java
@@ -54,8 +54,11 @@ public class PacketUtils {
 	public static boolean ppp=false;
 	
 	public static byte[] pppHead_static={0x11,0x00,0x44,0x44,0x00,0x44,0x00,0x21};
-	
-	
+
+	private PacketUtils() {
+	}
+
+
 	public static Packet buildIpV4(
 			MacAddress srcAddress_mac,
 			MacAddress dstAddrress_mac,

--- a/src/main/java/net/fs/rudp/message/MessageType.java
+++ b/src/main/java/net/fs/rudp/message/MessageType.java
@@ -92,4 +92,6 @@ public class MessageType {
 	public static short sType_PingMessager=321;
 	public static short sType_PingMessager2=322;
 
+	private MessageType() {
+	}
 }

--- a/src/main/java/net/fs/utils/ByteIntConvert.java
+++ b/src/main/java/net/fs/utils/ByteIntConvert.java
@@ -3,8 +3,11 @@ package net.fs.utils;
 
 
 public class ByteIntConvert {
-    
-    public static int toInt(byte[] b,int offset) { 
+
+    private ByteIntConvert() {
+    }
+
+    public static int toInt(byte[] b, int offset) { 
     	return b[offset + 3] & 0xff | (b[offset + 2] & 0xff) << 8
         | (b[offset + 1] & 0xff) << 16 | (b[offset] & 0xff) << 24;
     }

--- a/src/main/java/net/fs/utils/ByteShortConvert.java
+++ b/src/main/java/net/fs/utils/ByteShortConvert.java
@@ -2,8 +2,11 @@
 package net.fs.utils;
 
 public final class ByteShortConvert {
-   
-    public static byte[] toByteArray(short i,byte[] b,int offset) {
+
+    private ByteShortConvert() {
+    }
+
+    public static byte[] toByteArray(short i, byte[] b, int offset) {
     	 b[offset] = (byte) (i >> 8);
     	   b[offset + 1] = (byte) (i >> 0);
         return b; 

--- a/src/main/java/net/fs/utils/Tools.java
+++ b/src/main/java/net/fs/utils/Tools.java
@@ -11,6 +11,9 @@ import javax.net.ssl.SSLSession;
 
 public class Tools {
 
+	private Tools() {
+	}
+
 	public static HttpURLConnection getConnection(String urlString) throws Exception{
 		URL url = new URL(urlString);
 		HttpURLConnection conn = null;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - “Utility classes should not have public constructors ”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118

Please let me know if you have any questions.
Ayman Abdelghany.
