### PR TITLE
[squid:S1319] Declarations should use Java collection interfaces such as "List" rather than specific implementation classes such as "LinkedList"

### DIFF
--- a/src/main/java/net/fs/cap/CapEnv.java
+++ b/src/main/java/net/fs/cap/CapEnv.java
@@ -52,6 +52,7 @@ import java.net.UnknownHostException;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.LinkedBlockingQueue;
 
@@ -299,7 +300,7 @@ public class CapEnv {
 
 	void detectInterface() {
 		List<PcapNetworkInterface> allDevs = null;
-		HashMap<PcapNetworkInterface, PcapHandle> handleTable=new HashMap<PcapNetworkInterface, PcapHandle>();
+		Map<PcapNetworkInterface, PcapHandle> handleTable=new HashMap<PcapNetworkInterface, PcapHandle>();
 		try {
 			allDevs = Pcaps.findAllDevs();
 		} catch (PcapNativeException e1) {

--- a/src/main/java/net/fs/cap/PacketUtils.java
+++ b/src/main/java/net/fs/cap/PacketUtils.java
@@ -40,6 +40,7 @@ import org.pcap4j.util.MacAddress;
 
 import java.net.Inet4Address;
 import java.util.ArrayList;
+import java.util.List;
 
 public class PacketUtils {
 	
@@ -250,7 +251,7 @@ public class PacketUtils {
 		//builder_tcp.fin(tcpHeader.getFin());
 
 
-		ArrayList<TcpOption> tcp_options=new ArrayList<TcpOption>();
+		List<TcpOption> tcp_options=new ArrayList<TcpOption>();
 		
 		TcpNoOperationOption nop=TcpNoOperationOption.getInstance();
 
@@ -333,7 +334,7 @@ public class PacketUtils {
 		
 		TcpNoOperationOption nop=TcpNoOperationOption.getInstance();
 		
-		ArrayList<TcpOption> tcp_options=new ArrayList<TcpOption>();
+		List<TcpOption> tcp_options=new ArrayList<TcpOption>();
 		
 		TcpMaximumSegmentSizeOption seg_option=new TcpMaximumSegmentSizeOption.Builder().maxSegSize(mtu).correctLengthAtBuild(true).build();
 		tcp_options.add(seg_option);

--- a/src/main/java/net/fs/cap/TCPTun.java
+++ b/src/main/java/net/fs/cap/TCPTun.java
@@ -36,12 +36,14 @@ import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Random;
+import java.util.Set;
 
 
 public class TCPTun {
 
-	HashMap<Integer,TcpPacket>  sendedTable_server=new HashMap<Integer,TcpPacket> ();
+	Map<Integer,TcpPacket> sendedTable_server=new HashMap<Integer,TcpPacket> ();
 	HashMap<Integer,TcpPacket>  sendedTable_history_server=new HashMap<Integer,TcpPacket> ();
 
 	int clientSequence=Integer.MIN_VALUE;
@@ -50,7 +52,7 @@ public class TCPTun {
 
 	PcapHandle sendHandle;
 
-	HashSet<Short> selfAckTable=new HashSet<Short>();
+	Set<Short> selfAckTable=new HashSet<Short>();
 
 	HashMap<Integer, SendRecord> sendrecordTable=new HashMap<Integer, SendRecord>();
 

--- a/src/main/java/net/fs/cap/TunManager.java
+++ b/src/main/java/net/fs/cap/TunManager.java
@@ -24,10 +24,11 @@ import net.fs.utils.MLog;
 
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Map;
 
 public class TunManager {
 	
-	HashMap<String, TCPTun> connTable=new HashMap<String, TCPTun>();
+	Map<String, TCPTun> connTable=new HashMap<String, TCPTun>();
 	
 	static TunManager tunManager;
 	

--- a/src/main/java/net/fs/client/MapClient.java
+++ b/src/main/java/net/fs/client/MapClient.java
@@ -17,6 +17,7 @@ import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.util.HashSet;
 import java.util.Random;
+import java.util.Set;
 
 public class MapClient implements Trafficlistener{
 
@@ -46,7 +47,7 @@ public class MapClient implements Trafficlistener{
 
 	int connNum=0;
 	
-	HashSet<ClientProcessorInterface> processTable=new HashSet<ClientProcessorInterface>();
+	Set<ClientProcessorInterface> processTable=new HashSet<ClientProcessorInterface>();
 	
 	Object syn_process=new Object();
 	

--- a/src/main/java/net/fs/client/PortMapManager.java
+++ b/src/main/java/net/fs/client/PortMapManager.java
@@ -11,6 +11,7 @@ import java.net.ServerSocket;
 import java.net.Socket;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Map;
 
 import com.alibaba.fastjson.JSONArray;
 import com.alibaba.fastjson.JSONObject;
@@ -22,7 +23,7 @@ public class PortMapManager {
 	
 	ArrayList<MapRule> mapList=new ArrayList<MapRule>();
 	
-	HashMap<Integer, MapRule> mapRuleTable=new HashMap<Integer, MapRule>();
+	Map<Integer, MapRule> mapRuleTable=new HashMap<Integer, MapRule>();
 	
 	String configFilePath="port_map.json";
 	

--- a/src/main/java/net/fs/rudp/AckListManage.java
+++ b/src/main/java/net/fs/rudp/AckListManage.java
@@ -3,10 +3,11 @@ package net.fs.rudp;
 
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Map;
 
 public class AckListManage implements Runnable{
 	Thread mainThread;
-	HashMap<Integer, AckListTask> taskTable;
+	Map<Integer, AckListTask> taskTable;
 	public AckListManage(){
 		taskTable=new HashMap<Integer, AckListTask>();
 		mainThread=new Thread(this);

--- a/src/main/java/net/fs/rudp/AckListTask.java
+++ b/src/main/java/net/fs/rudp/AckListTask.java
@@ -3,6 +3,8 @@ package net.fs.rudp;
 
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 import net.fs.rudp.message.AckListMessage;
 
@@ -13,7 +15,7 @@ public class AckListTask {
 	int lastRead=0;
 	ArrayList<Integer> ackList;
 	@SuppressWarnings("unchecked")
-	HashSet set;
+	Set set;
 	AckListTask(ConnectionUDP conn){
 		this.conn=conn;
 		ackList=new ArrayList();
@@ -61,7 +63,7 @@ public class AckListTask {
 		}
 	}
 	
-	ArrayList<Integer> copy(int offset,int length,ArrayList<Integer> ackList){
+	ArrayList<Integer> copy(int offset,int length,List<Integer> ackList){
 		ArrayList<Integer> nl= new ArrayList<Integer>();
 		for(int i=0;i<length;i++){
 			nl.add(ackList.get(offset+i));

--- a/src/main/java/net/fs/rudp/ClientControl.java
+++ b/src/main/java/net/fs/rudp/ClientControl.java
@@ -6,6 +6,7 @@ import java.net.DatagramPacket;
 import java.net.InetAddress;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Random;
 
 import net.fs.rudp.message.PingMessage;
@@ -23,7 +24,7 @@ public class ClientControl {
 	
 	Object synlock=new Object();
 	
-	private HashMap<Integer, SendRecord> sendRecordTable=new HashMap<Integer, SendRecord>();
+	private Map<Integer, SendRecord> sendRecordTable=new HashMap<Integer, SendRecord>();
 
 	
 	HashMap<Integer, SendRecord> sendRecordTable_remote=new HashMap<Integer, SendRecord>();
@@ -49,7 +50,7 @@ public class ClientControl {
 	
 	Random ran=new Random();
 	
-	HashMap<Integer, Long> pingTable=new HashMap<Integer, Long>();
+	Map<Integer, Long> pingTable=new HashMap<Integer, Long>();
 	
 	public int pingDelay=250;
 	
@@ -67,7 +68,7 @@ public class ClientControl {
 	
 	int dstPort;
 	
-	public HashMap<Integer, ConnectionUDP> connTable=new  HashMap<Integer, ConnectionUDP>();
+	public Map<Integer, ConnectionUDP> connTable=new  HashMap<Integer, ConnectionUDP>();
 		
 	Object syn_connTable=new Object();
 	

--- a/src/main/java/net/fs/rudp/ClientManager.java
+++ b/src/main/java/net/fs/rudp/ClientManager.java
@@ -5,13 +5,14 @@ import java.net.InetAddress;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Map;
 
 import net.fs.utils.MLog;
 
 
 public class ClientManager {
 	
-	HashMap<Integer, ClientControl> clientTable=new HashMap<Integer, ClientControl>();
+	Map<Integer, ClientControl> clientTable=new HashMap<Integer, ClientControl>();
 	
 	Thread mainThread;
 	

--- a/src/main/java/net/fs/rudp/Receiver.java
+++ b/src/main/java/net/fs/rudp/Receiver.java
@@ -5,6 +5,7 @@ import java.net.DatagramPacket;
 import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Map;
 
 import net.fs.rudp.message.AckListMessage;
 import net.fs.rudp.message.CloseMessage_Conn;
@@ -18,7 +19,7 @@ public class Receiver {
 	Sender sender;
 	public InetAddress dstIp;
 	public int dstPort;
-	HashMap<Integer, DataMessage> receiveTable=new HashMap<Integer, DataMessage>();
+	Map<Integer, DataMessage> receiveTable=new HashMap<Integer, DataMessage>();
 	int lastRead=-1;
 	int lastReceive=-1;
 	Object availOb=new Object();

--- a/src/main/java/net/fs/rudp/Route.java
+++ b/src/main/java/net/fs/rudp/Route.java
@@ -8,7 +8,9 @@ import java.net.InetAddress;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
+import java.util.Set;
 import java.util.Vector;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.SynchronousQueue;
@@ -26,7 +28,7 @@ import net.fs.utils.MessageCheck;
 public class Route {
 
 	private DatagramSocket ds;
-	public HashMap<Integer, ConnectionUDP> connTable;
+	public Map<Integer, ConnectionUDP> connTable;
 	Route route;
 	Thread mainThread;
 	Thread reveiveThread;
@@ -53,11 +55,11 @@ public class Route {
 	
 	String pocessName="";
 
-	HashSet<Integer> setedTable=new HashSet<Integer>();
+	Set<Integer> setedTable=new HashSet<Integer>();
 
 	static int vv;
 
-	HashSet<Integer> closedTable=new HashSet<Integer>();
+	Set<Integer> closedTable=new HashSet<Integer>();
 
 	public static int localDownloadSpeed,localUploadSpeed;
 

--- a/src/main/java/net/fs/rudp/Sender.java
+++ b/src/main/java/net/fs/rudp/Sender.java
@@ -6,6 +6,7 @@ import java.net.DatagramPacket;
 import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Random;
 
 import net.fs.rudp.message.AckListMessage;
@@ -24,7 +25,7 @@ public class Sender {
 	boolean bussy=false;
 	Object bussyOb=new Object();
 	boolean isHave=false;
-	public HashMap<Integer, DataMessage> sendTable=new HashMap<Integer, DataMessage>();
+	public Map<Integer, DataMessage> sendTable=new HashMap<Integer, DataMessage>();
 	boolean isReady=false;
 	Object readyOb=new Object();
 	Object winOb=new Object();

--- a/src/main/java/net/fs/rudp/message/AckListMessage.java
+++ b/src/main/java/net/fs/rudp/message/AckListMessage.java
@@ -8,6 +8,7 @@ import net.fs.utils.ByteShortConvert;
 import java.net.DatagramPacket;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Map;
 
 
 public class AckListMessage extends Message{
@@ -18,9 +19,9 @@ public class AckListMessage extends Message{
 	int r1,r2,r3,s1,s2,s3;
 
 	@SuppressWarnings("unchecked")
-	public AckListMessage(long connId,ArrayList ackList,int lastRead,
-			HashMap<Integer, SendRecord> sendRecordTable,int timeId,
-			int connectId,int clientId){
+	public AckListMessage(long connId, ArrayList ackList, int lastRead,
+						  Map<Integer, SendRecord> sendRecordTable, int timeId,
+						  int connectId, int clientId){
 		this.clientId=clientId;
 		this.connectId=connectId;
 		this.ackList=ackList;

--- a/src/main/java/net/fs/utils/LogOutputStream.java
+++ b/src/main/java/net/fs/utils/LogOutputStream.java
@@ -4,10 +4,11 @@ package net.fs.utils;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.util.HashSet;
+import java.util.Set;
 
 public class LogOutputStream extends PrintStream{
 	
-	HashSet<LogListener> listeners=new HashSet<LogListener>();
+	Set<LogListener> listeners=new HashSet<LogListener>();
 	
 	StringBuffer buffer=new StringBuffer();
 	

--- a/src/main/java/net/fs/utils/NetStatus.java
+++ b/src/main/java/net/fs/utils/NetStatus.java
@@ -19,6 +19,7 @@
 
 package net.fs.utils;
 
+import java.util.List;
 import java.util.Vector;
 
 
@@ -31,7 +32,7 @@ public class NetStatus {
 	
 	int averageTime;
 	
-	Vector<SpeedUnit> speedList;
+	List<SpeedUnit> speedList;
 	SpeedUnit currentUnit;
 	
 	public int upSpeed=0;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1319 - “Declarations should use Java collection interfaces such as "List" rather than specific implementation classes such as "LinkedList" ”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1319

Please let me know if you have any questions.
Ayman Abdelghany.
